### PR TITLE
add TrkDtc fragment and the corresponding type

### DIFF
--- a/artdaq-core-mu2e/Data/ArtFragment.hh
+++ b/artdaq-core-mu2e/Data/ArtFragment.hh
@@ -4,9 +4,7 @@
 #include "artdaq-core/Data/Fragment.hh"
 #include "artdaq-core/Data/dictionarycontrol.hh"
 #include "cetlib_except/exception.h"
-// #if HIDE_FROM_ROOT
 #include "dtcInterfaceLib/DTC_Packets.h"
-// #endif
 
 #include <iostream>
 
@@ -32,7 +30,6 @@ struct mu2e::ArtFragment
 		: data_(data) {
 	}
 
-  // #if HIDE_FROM_ROOT  // Hide most things from ROOT
 	explicit ArtFragment(DTCLib::DTC_SubEvent const &se)
 	{
 		data_ = std::vector<uint8_t>(se.GetSubEventByteCount());
@@ -112,14 +109,11 @@ struct mu2e::ArtFragment
 		std::cout << std::endl;
 		return;
 	}
-  // #endif
 	
 	mutable bool setup_{false};
 	std::vector<uint8_t> data_;
 
-  // #if HIDE_FROM_ROOT  // Hide most things from ROOT
 	mutable DTCLib::DTC_SubEvent event_;  //! presume transient
-  // #endif
 };
 
 #endif /* mu2e_artdaq_Overlays_ArtFragment_hh */

--- a/artdaq-core-mu2e/Data/ArtFragment.hh
+++ b/artdaq-core-mu2e/Data/ArtFragment.hh
@@ -4,9 +4,9 @@
 #include "artdaq-core/Data/Fragment.hh"
 #include "artdaq-core/Data/dictionarycontrol.hh"
 #include "cetlib_except/exception.h"
-#if HIDE_FROM_ROOT
+// #if HIDE_FROM_ROOT
 #include "dtcInterfaceLib/DTC_Packets.h"
-#endif
+// #endif
 
 #include <iostream>
 
@@ -32,7 +32,7 @@ struct mu2e::ArtFragment
 		: data_(data) {
 	}
 
-#if HIDE_FROM_ROOT  // Hide most things from ROOT
+  // #if HIDE_FROM_ROOT  // Hide most things from ROOT
 	explicit ArtFragment(DTCLib::DTC_SubEvent const &se)
 	{
 		data_ = std::vector<uint8_t>(se.GetSubEventByteCount());
@@ -112,15 +112,14 @@ struct mu2e::ArtFragment
 		std::cout << std::endl;
 		return;
 	}
-#endif
+  // #endif
 	
-
 	mutable bool setup_{false};
 	std::vector<uint8_t> data_;
 
-#if HIDE_FROM_ROOT  // Hide most things from ROOT
-	mutable DTCLib::DTC_SubEvent event_;
-#endif
+  // #if HIDE_FROM_ROOT  // Hide most things from ROOT
+	mutable DTCLib::DTC_SubEvent event_;  //! presume transient
+  // #endif
 };
 
 #endif /* mu2e_artdaq_Overlays_ArtFragment_hh */

--- a/artdaq-core-mu2e/Data/TrkDtcFragment.hh
+++ b/artdaq-core-mu2e/Data/TrkDtcFragment.hh
@@ -1,0 +1,26 @@
+
+#ifndef ARTDAQ_CORE_MU2E_DATA_TRKDTC_HH
+#define ARTDAQ_CORE_MU2E_DATA_TRKDTC_HH
+
+#include "artdaq-core-mu2e/Data/ArtFragment.hh"
+
+namespace mu2e {
+  class TrkDtcFragment : public ArtFragment {
+    
+  public:
+
+    TrkDtcFragment() : ArtFragment() {}
+    TrkDtcFragment(const std::vector<uint8_t>& Data) : ArtFragment(Data) {}
+
+//-----------------------------------------------------------------------------
+// the first integer word - version
+//-----------------------------------------------------------------------------
+    int      nReg    () { return (data_.size()/4-1)/2; }
+
+    int      version () { return ((int*) data_.data())[0    ]; }
+    uint32_t reg(int i) { return ((int*) data_.data())[2*i+1]; }
+    uint32_t val(int i) { return ((int*) data_.data())[2*i+2]; }
+  };
+}
+
+#endif

--- a/artdaq-core-mu2e/Overlays/FragmentType.hh
+++ b/artdaq-core-mu2e/Overlays/FragmentType.hh
@@ -8,17 +8,18 @@ namespace mu2e {
 namespace detail {
 enum FragmentType : artdaq::Fragment::type_t
 {
-	EMPTY = artdaq::Fragment::EmptyFragmentType,
+	EMPTY  = artdaq::Fragment::EmptyFragmentType,
 	MISSED = artdaq::Fragment::FirstUserFragmentType,
 	//DTC = artdaq::Fragment::FirstUserFragmentType + 1,  // DEPRECATED
 	//MU2E = artdaq::Fragment::FirstUserFragmentType + 2, // DEPRECATED
 	//MU2EEVENT = artdaq::Fragment::FirstUserFragmentType + 3, // DEPRECATED
-	TRK = artdaq::Fragment::FirstUserFragmentType + 4,     // Tracker fragment
-	CAL = artdaq::Fragment::FirstUserFragmentType + 5,     // Calorimeter fragment
-	CRV = artdaq::Fragment::FirstUserFragmentType + 6,     // Cosmic Ray Veto fragment
-	DBG = artdaq::Fragment::FirstUserFragmentType + 7,     // Debug Packet Fragment
+	TRK    = artdaq::Fragment::FirstUserFragmentType + 4,     // Tracker fragment
+	CAL    = artdaq::Fragment::FirstUserFragmentType + 5,     // Calorimeter fragment
+	CRV    = artdaq::Fragment::FirstUserFragmentType + 6,     // Cosmic Ray Veto fragment
+	DBG    = artdaq::Fragment::FirstUserFragmentType + 7,     // Debug Packet Fragment
 	DTCEVT = artdaq::Fragment::FirstUserFragmentType + 8,  // DTC Event Fragment
-	STM = artdaq::Fragment::FirstUserFragmentType + 9,     // Stopping Target Monitor fragment
+	STM    = artdaq::Fragment::FirstUserFragmentType + 9,     // Stopping Target Monitor fragment
+  TRKDTC = artdaq::Fragment::FirstUserFragmentType +10,     // hardware debug info
 	INVALID  // Should always be last.
 };
 
@@ -33,12 +34,13 @@ std::unordered_map<FragmentType, std::string> const names{
 	//{FragmentType::DTC, "DTC"},   // DEPRECATED
 	//{FragmentType::MU2E, "MU2E"}, // DEPRECATED
 	//{FragmentType::MU2EEVENT, "MU2EEVENT"},
-	{FragmentType::TRK, "TRK"},
-	{FragmentType::CAL, "CAL"},
-	{FragmentType::CRV, "CRV"},
-	{FragmentType::DBG, "DBG"},
+	{FragmentType::TRK   , "TRK"   },
+	{FragmentType::CAL   , "CAL"   },
+	{FragmentType::CRV   , "CRV"   },
+	{FragmentType::DBG   , "DBG"   },
 	{FragmentType::DTCEVT, "DTCEVT"},
-	{FragmentType::STM, "STM"}
+  {FragmentType::STM   , "STM"   },
+  {FragmentType::TRKDTC, "TRKDTC"},
 };
 
 FragmentType toFragmentType(std::string t_string);


### PR DESCRIPTION
also comment out a few HIDE_FROM_ROOT clauses: 

- after the TRACE includes got protected, this is no longer necessary. 
- ROOT dictionaries are not denerated anyway