### PR TITLE
Checkpoint after initial test with Erdem of new DTC emulating the CFO…

### DIFF
--- a/artdaq-core-mu2e/Overlays/DTC_Types.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Types.h
@@ -1174,7 +1174,6 @@ struct DTC_EventMode
 	bool isOnSpillFlagSet() const 			{return mode4 & 1;}
 	bool isSubRunBitSet() const 			{return mode4 & 2;}
 	bool isPredictiveSubRunBitSet() const 	{return mode4 & 4;}
-	uint8_t getDeliveryRingRFMarkerTDC() const 	{return mode4 >> 8;}
 };
 
 struct DTC_EVBStatus

--- a/artdaq-core-mu2e/Overlays/DTC_Types.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Types.h
@@ -1170,6 +1170,11 @@ struct DTC_EventMode
 		const_cast<uint8_t*>(arr)[start + 3] = mode3;
 		const_cast<uint8_t*>(arr)[start + 4] = mode4;
 	}
+	
+	bool isOnSpillFlagSet() const 			{return mode4 & 1;}
+	bool isSubRunBitSet() const 			{return mode4 & 2;}
+	bool isPredictiveSubRunBitSet() const 	{return mode4 & 4;}
+	uint8_t getDeliveryRingRFMarkerTDC() const 	{return mode4 >> 8;}
 };
 
 struct DTC_EVBStatus


### PR DESCRIPTION
…; all functionality verified for STM VST, however runaway repeats did happen with preset runplan (but could not be repeated after adding DTC ILAs)