### PR TITLE
SetupSubEvent() in DTCDataDecoder

### DIFF
--- a/artdaq-core-mu2e/Data/DTCDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/DTCDataDecoder.hh
@@ -41,12 +41,14 @@ struct mu2e::DTCDataDecoder
 		
 		auto ptr = data_.data();
 		event_ = DTCLib::DTC_SubEvent(ptr);	
+                event_.SetupSubEvent();
 		setup_ = true;
 	}
 
 	void setup_event() const {
 		auto ptr = data_.data();
 		event_ = DTCLib::DTC_SubEvent(ptr);	
+                event_.SetupSubEvent();
 		setup_ = true;
 		}
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -17,8 +17,8 @@ bindir      fq_dir      bin
 
 # for e20:s116
 product				version		optional
-artdaq_core                     v3_09_16
-cetmodules			v3_22_02	-	only_for_build
+artdaq_core                     v3_10_01
+cetmodules			v3_24_01	-	only_for_build
 end_product_list
 
 # e6  - with gcc 4.9.1 and -std=c++1y

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -17,8 +17,8 @@ bindir      fq_dir      bin
 
 # for e20:s116
 product				version		optional
-artdaq_core                     v3_10_01
-cetmodules			v3_24_01	-	only_for_build
+artdaq_core                     v3_09_16
+cetmodules			v3_22_02	-	only_for_build
 end_product_list
 
 # e6  - with gcc 4.9.1 and -std=c++1y


### PR DESCRIPTION
Some parts of the DTC_SubEvent constructor were moved to DTC_SubEvent::SetupSubEvent() during recent changes. Therefore, SetupSubEvent() should also be added to the DTCDataDecoder constructor and setup_event() function.