### PR TITLE
Add new data members to EventHeader

### DIFF
--- a/artdaq-core-mu2e/Data/EventHeader.cc
+++ b/artdaq-core-mu2e/Data/EventHeader.cc
@@ -25,8 +25,11 @@ namespace mu2e {
 
     os <<  "EWT: "           << std::setw(ewt_decimal_digits) << eh.ewt
        << " Event Mode: "    << buf1
-       << " RF_Marker_TDC: " << int(eh.rfmTDC)
-       << " Flags: "         << buf2;
+       << " RF0_est: "       << unsigned(eh.rfmTDC_est)
+       << " Flags: "         << buf2
+       << " Duration: "      << unsigned(eh.eventDuration)
+       << " RF0_meas: "      << unsigned(eh.rfmTDC_measured);
+
     return os;
   }
 

--- a/artdaq-core-mu2e/Data/EventHeader.hh
+++ b/artdaq-core-mu2e/Data/EventHeader.hh
@@ -5,13 +5,14 @@
 //
 // Notes:
 //  1) See Mu2e-doc-4914 for the definition of the informaton in the Heartbeat packet.
+//     See Mu2e-doc-19095, page 22 for the definition of the propose CFO Event Window Data Record.
 //  2) EventWindowTag is redundant with the art::EventId but having it will be useful for
 //     consistency checking, particularly during commissioning and after major
 //     upgrades to TDAQ.
 //     Cost to keep this: about 200 GB in Raw data files summed over nominal Mu2e running.
 //     Estimate O(10) times that summed over all derived data products.
 //  3) Did not use std::bitset for flags since, in  g++ 9.3.0, it allocates space in chunks of 32 bits.
-//  4) Fixme: add additional named bits in flags and EventMode as they are defined; maybe create 
+//  4) Fixme: add additional named bits in flags and EventMode as they are defined; maybe create
 //            separate classes for these?
 //  5) Fixme: in the member function isFlagBit set, the code with thrown an exception if the requested
 //            bit is out of range.  Is this the behaviour we want?
@@ -41,13 +42,29 @@ struct EventHeader {
     rnr_check(rnrCheck), ndtc_check(ndtcCheck), dtc_check(dtcCheck), ewt_check(ewtCheck) {
   }
 
-  EWT        ewt   = 0;  // Event Window Tag
-  uint32_t   mode  = 0;  // Event Mode
-  uint8_t   rfmTDC = 0;  // RF Marker TDC
-  uint8_t    flags = 0;  // on-spill bit and reserved flags
+  EventHeader( EWT ewt, uint32_t mode, uint8_t rfmTDC_est, uint8_t flags, uint16_t eventDuration, uint8_t rfmTDC_measured ):
+    ewt(ewt), mode(mode), rfmTDC_est(rfmTDC_est), flags(flags), eventDuration(eventDuration), rfmTDC_measured(rfmTDC_measured),
+    rnr_check(0), ndtc_check(0), dtc_check(0), ewt_check(0) {
+  }
+
+  EventHeader( EWT ewt, uint32_t mode, uint8_t rfmTDC_est, uint8_t flags, uint16_t eventDuration, uint8_t rfmTDC_measured,
+               uint8_t rnrCheck, uint8_t ndtcCheck, uint8_t dtcCheck, uint8_t ewtCheck):
+    ewt(ewt), mode(mode), rfmTDC_est(rfmTDC_est), flags(flags), eventDuration(eventDuration), rfmTDC_measured(rfmTDC_measured),
+    rnr_check(rnrCheck), ndtc_check(ndtcCheck), dtc_check(dtcCheck), ewt_check(ewtCheck) {
+  }
+
+  // Information from the Heartbeat Packet
+  EWT        ewt        = 0;  // Event Window Tag
+  uint32_t   mode       = 0;  // Event Mode
+  uint8_t    rfmTDC_est = 0;  // RF Marker TDC
+  uint8_t    flags      = 0;  // on-spill bit and reserved flags
+
+  // Information from the CFO Event Window Data Record
+  uint16_t eventDuration   = 0;
+  uint8_t  rfmTDC_measured = 0;
 
   uint8_t    rnr_check : 1; //Round-robin check
-  uint8_t    ndtc_check : 1; //cehck if nDTCs used in the event matches the configured value
+  uint8_t    ndtc_check : 1; //check if nDTCs used in the event matches the configured value
   uint8_t    dtc_check : 1; //Check we have all the DTCs used in the event
   uint8_t    ewt_check : 1; //eventHeader EWT consistency with the subEvents header
 
@@ -60,11 +77,11 @@ struct EventHeader {
   }
 
   bool isFlagBitSet( int bit) const;
-  
+
   void initErrorChecks(){
     rnr_check  = 1;
     dtc_check  = 1;
-    ndtc_check = 1; 
+    ndtc_check = 1;
     ewt_check  = 1;
   }
 };


### PR DESCRIPTION
Add measured RF0 and event duration from the CFO EventWindow Data Record
Add c'tors that initialize these.
Update comments.
Fix typo in existing comment.

I decided not to include the following fields from the CFO EventWindow Data Record.
  - 6 byte Event Window Tag - already present above.
  - 4 byte linux seconds timestamp - only record it in Run and SubRun headers
  - 1 byte estimate of DR marker for event N - already present above
  - 1 byte estimate of DR marker for event N+1 - will be present in event N+1
  - 1 byte measurement of DR marker for event N+1 - will be present in event N+1