### PR TITLE
now we can save the decoded data packets in the ROOT file

### DIFF
--- a/artdaq-core-mu2e/Data/CRVDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/CRVDataDecoder.hh
@@ -112,6 +112,7 @@ public:
 	std::vector<CRVHit> GetCRVHits(size_t blockIndex) const;
 
 };
+  using CRVDataDecoders = std::vector<CRVDataDecoder>;
 }  // namespace mu2e
 
 #endif  // ARTDAQ_CORE_MU2E_DATA_CRVDATADECODER_HH

--- a/artdaq-core-mu2e/Data/CalorimeterDataDecoder.cc
+++ b/artdaq-core-mu2e/Data/CalorimeterDataDecoder.cc
@@ -320,6 +320,5 @@ namespace mu2e {
 
     return output;
   }
-  
 
 } // namespace mu2e

--- a/artdaq-core-mu2e/Data/CalorimeterDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/CalorimeterDataDecoder.hh
@@ -1,9 +1,8 @@
 #ifndef ARTDAQ_CORE_MU2E_DATA_CALORIMETERDATADECODER_HH
 #define ARTDAQ_CORE_MU2E_DATA_CALORIMETERDATADECODER_HH
 
-#include "artdaq-core-mu2e/Data/DTCDataDecoder.hh"
 
-#include "TRACE/tracemf.h"
+#include "artdaq-core-mu2e/Data/DTCDataDecoder.hh"
 
 #include <messagefacility/MessageLogger/MessageLogger.h> // Putting this here so that Offline/DAQ/src/FragmentAna_module.cc can use it
 
@@ -142,5 +141,7 @@ namespace mu2e {
     std::unique_ptr<CalorimeterFooterPacket> GetCalorimeterFooter(size_t blockIndex) const;
     std::vector<std::pair<CalorimeterHitDataPacket, uint16_t>> GetCalorimeterHitsForTrigger(size_t blockIndex) const;
   };
+
+  using CalorimeterDataDecoders = std::vector<CalorimeterDataDecoder>;
 }  // namespace mu2e
-#endif 
+#endif /* mu2e_artdaq_Data_CalorimeterDataDecoder_hh */

--- a/artdaq-core-mu2e/Data/classes.h
+++ b/artdaq-core-mu2e/Data/classes.h
@@ -3,4 +3,10 @@
 #include "artdaq-core-mu2e/Data/SubRunHeader.hh"
 #include "artdaq-core-mu2e/Data/EventHeader.hh"
 #include "artdaq-core-mu2e/Data/Mu2eEventHeader.hh"
+#include "artdaq-core-mu2e/Data/DTCDataDecoder.hh"
+#include "artdaq-core-mu2e/Data/TrackerDataDecoder.hh"
+#include "artdaq-core-mu2e/Data/CalorimeterDataDecoder.hh"
+#include "artdaq-core-mu2e/Data/CRVDataDecoder.hh"
+#include <vector>
 #include "canvas/Persistency/Common/Wrapper.h"
+

--- a/artdaq-core-mu2e/Data/classes_def.xml
+++ b/artdaq-core-mu2e/Data/classes_def.xml
@@ -9,5 +9,19 @@
   <class name="art::Wrapper<mu2e::EventHeader>"/>
   <class name="mu2e::Mu2eEventHeader" />
   <class name="art::Wrapper<mu2e::Mu2eEventHeader>"/>
-  
+  <class name="mu2e::DTCDataDecoder" />
+  <class name="art::Wrapper<mu2e::DTCDataDecoder>"/>
+  <class name="mu2e::CalorimeterDataDecoder" />
+  <class name="art::Wrapper<mu2e::CalorimeterDataDecoder>"/>
+  <class name="std::vector<mu2e::CalorimeterDataDecoder>" />
+  <class name="art::Wrapper<std::vector<mu2e::CalorimeterDataDecoder>>"/>
+  <class name="mu2e::TrackerDataDecoder" />
+  <class name="art::Wrapper<mu2e::TrackerDataDecoder>"/>
+  <class name="std::vector<mu2e::TrackerDataDecoder>" />
+  <class name="art::Wrapper<std::vector<mu2e::TrackerDataDecoder>>"/>
+  <class name="mu2e::CRVDataDecoder" />
+  <class name="art::Wrapper<mu2e::CRVDataDecoder>"/>
+  <class name="std::vector<mu2e::CRVDataDecoder>" />
+  <class name="art::Wrapper<std::vector<mu2e::CRVDataDecoder>>"/>
+
 </lcgdict>


### PR DESCRIPTION
We added the possibility of saving the decoded data packets in the ROOT file. This feature is useful for commissioning and debugging. 
@giro94 and I tested it with the test stand at SiDet.