### PR TITLE
Updated overlay classes to accomodate the new link subsystem ids

### DIFF
--- a/artdaq-core-mu2e/Data/CalorimeterDataDecoder.cc
+++ b/artdaq-core-mu2e/Data/CalorimeterDataDecoder.cc
@@ -200,6 +200,11 @@ namespace mu2e {
       return output;
     }
 
+    if(dataBlock->GetHeader()->GetSubsystem() != DTCLib::DTC_Subsystem_Calorimeter) {
+      TLOG(TLVL_DEBUG) << "CalorimeterDataDecoder::GetCalorimeterHitTestData : this block is from different subsystem: " << dataBlock->GetHeader()->GetSubsystem();
+      return output;
+    }
+
     DTCLib::DTC_DataHeaderPacket* blockHeader = dataBlock->GetHeader().get();
     size_t blockSize = dataBlock->byteSize;
     size_t nPackets = blockHeader->GetPacketCount();

--- a/artdaq-core-mu2e/Data/CalorimeterDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/CalorimeterDataDecoder.hh
@@ -138,6 +138,7 @@ namespace mu2e {
     std::vector<std::pair<CalorimeterHitDataPacket, std::vector<uint16_t>>>* GetCalorimeterHitData(size_t blockIndex) const;
     std::vector<std::pair<CalorimeterHitTestDataPacket, std::vector<uint16_t>>>* GetCalorimeterHitTestData(size_t blockIndex) const;
     std::vector<std::pair<CalorimeterCountersDataPacket, std::vector<uint32_t>>>* GetCalorimeterCountersData(size_t blockIndex) const;
+    std::vector<std::pair<CalorimeterCountersDataPacket, std::vector<uint32_t>>>* GetEmulatedCountersData(size_t blockIndex) const;
     std::unique_ptr<CalorimeterFooterPacket> GetCalorimeterFooter(size_t blockIndex) const;
     std::vector<std::pair<CalorimeterHitDataPacket, uint16_t>> GetCalorimeterHitsForTrigger(size_t blockIndex) const;
   };

--- a/artdaq-core-mu2e/Data/DTCDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/DTCDataDecoder.hh
@@ -41,14 +41,14 @@ struct mu2e::DTCDataDecoder
 		
 		auto ptr = data_.data();
 		event_ = DTCLib::DTC_SubEvent(ptr);	
-                event_.SetupSubEvent();
+		event_.SetupSubEvent();
 		setup_ = true;
 	}
 
 	void setup_event() const {
 		auto ptr = data_.data();
 		event_ = DTCLib::DTC_SubEvent(ptr);	
-                event_.SetupSubEvent();
+		event_.SetupSubEvent();
 		setup_ = true;
 		}
 

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.h
@@ -84,20 +84,32 @@ public:
 		for (size_t ii = 0; ii < sub_events_.size(); ++ii)
 		{
 			if (sub_events_[ii].GetDTCID() == dtc && sub_events_[ii].GetSubsystem() == static_cast<uint8_t>(subsys))
-                return &sub_events_[ii];
+				return &sub_events_[ii];
 		}
 		return nullptr;
 	}
 
 	std::vector<DTC_SubEvent> GetSubsystemData(DTC_Subsystem subsys) const {
 		std::vector<DTC_SubEvent> output;
-
 		for(auto& subevt : sub_events_) {
-			if(subevt.GetSubsystem() == subsys) {
+			if(subevt.HasSubsystem(subsys)) {
 				output.push_back(subevt);
 			}
 		}
+		return output;
+	}
 
+	std::vector<DTC_DataBlock> GetSubsystemBlocks(DTC_Subsystem subsys) const {
+		std::vector<DTC_DataBlock> output;
+		for(auto& subevt : sub_events_) {
+			if(subevt.HasSubsystem(subsys)) {
+				for(auto& datablock : subevt.GetDataBlocks()) {
+					if(static_cast<DTC_Subsystem>(datablock.GetHeader()->GetSubsystemID()) == subsys) {
+						output.push_back(datablock);
+					}
+				}
+			}
+		}
 		return output;
 	}
 

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.h
@@ -104,7 +104,7 @@ public:
 		for(auto& subevt : sub_events_) {
 			if(subevt.HasSubsystem(subsys)) {
 				for(auto& datablock : subevt.GetDataBlocks()) {
-					if(static_cast<DTC_Subsystem>(datablock.GetHeader()->GetSubsystemID()) == subsys) {
+					if(datablock.GetHeader()->GetSubsystem() == subsys) {
 						output.push_back(datablock);
 					}
 				}

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
@@ -61,14 +61,33 @@ public:
 		UpdateHeader();
 	}
 
-	DTC_Subsystem GetSubsystem() const { return static_cast<DTC_Subsystem>(header_.source_subsystem); }
+	DTC_Subsystem GetSubsystem(uint link = 0) const {
+		switch(link){
+			case 0: return static_cast<DTC_Subsystem>(header_.link0_subsystem); break;
+			case 1: return static_cast<DTC_Subsystem>(header_.link1_subsystem); break;
+			case 2: return static_cast<DTC_Subsystem>(header_.link2_subsystem); break;
+			case 3: return static_cast<DTC_Subsystem>(header_.link3_subsystem); break;
+			case 4: return static_cast<DTC_Subsystem>(header_.link4_subsystem); break;
+			case 5: return static_cast<DTC_Subsystem>(header_.link5_subsystem); break;
+			default: return static_cast<DTC_Subsystem>(0);
+		}
+	}
+	bool HasSubsystem(DTC_Subsystem subsys) const {
+		if (static_cast<DTC_Subsystem>(header_.link0_subsystem) == subsys) return true;
+		if (static_cast<DTC_Subsystem>(header_.link1_subsystem) == subsys) return true;
+		if (static_cast<DTC_Subsystem>(header_.link2_subsystem) == subsys) return true;
+		if (static_cast<DTC_Subsystem>(header_.link3_subsystem) == subsys) return true;
+		if (static_cast<DTC_Subsystem>(header_.link4_subsystem) == subsys) return true;
+		if (static_cast<DTC_Subsystem>(header_.link5_subsystem) == subsys) return true;
+		return false;
+	}
 	void SetDTCMAC(uint8_t mac) {
 		header_.dtc_mac = mac;
 	}
 	void SetSourceDTC(uint8_t id, DTC_Subsystem subsystem = DTC_Subsystem_Other)
 	{
 		header_.source_dtc_id = id;
-		header_.source_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link0_subsystem = static_cast<uint8_t>(subsystem); //This is deprecated TODO FIX
 	}
 	const DTC_SubEventHeader* GetHeader() const { return &header_; }
 	void UpdateHeader();

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <array>
 
 namespace DTCLib {
 
@@ -61,14 +62,14 @@ public:
 		UpdateHeader();
 	}
 
-	DTC_Subsystem GetSubsystem(uint link = 0) const {
+	DTC_Subsystem GetSubsystem(DTC_Link_ID link = DTC_Link_0) const {
 		switch(link){
-			case 0: return static_cast<DTC_Subsystem>(header_.link0_subsystem); break;
-			case 1: return static_cast<DTC_Subsystem>(header_.link1_subsystem); break;
-			case 2: return static_cast<DTC_Subsystem>(header_.link2_subsystem); break;
-			case 3: return static_cast<DTC_Subsystem>(header_.link3_subsystem); break;
-			case 4: return static_cast<DTC_Subsystem>(header_.link4_subsystem); break;
-			case 5: return static_cast<DTC_Subsystem>(header_.link5_subsystem); break;
+			case DTC_Link_0: return static_cast<DTC_Subsystem>(header_.link0_subsystem); break;
+			case DTC_Link_1: return static_cast<DTC_Subsystem>(header_.link1_subsystem); break;
+			case DTC_Link_2: return static_cast<DTC_Subsystem>(header_.link2_subsystem); break;
+			case DTC_Link_3: return static_cast<DTC_Subsystem>(header_.link3_subsystem); break;
+			case DTC_Link_4: return static_cast<DTC_Subsystem>(header_.link4_subsystem); break;
+			case DTC_Link_5: return static_cast<DTC_Subsystem>(header_.link5_subsystem); break;
 			default: return static_cast<DTC_Subsystem>(0);
 		}
 	}
@@ -84,15 +85,19 @@ public:
 	void SetDTCMAC(uint8_t mac) {
 		header_.dtc_mac = mac;
 	}
-	void SetSourceDTC(uint8_t id, DTC_Subsystem subsystem = DTC_Subsystem_Other)
-	{
+	void SetSourceDTC(uint8_t id, DTC_Subsystem subsystem = DTC_Subsystem_Other){
+		std::array<DTC_Subsystem, 6> subsystems;
+		subsystems.fill(subsystem); //Use same subsystem for all six links
+		SetSourceDTC(id,subsystems);
+	}
+	void SetSourceDTC(uint8_t id, std::array<DTC_Subsystem, 6> subsystems){
 		header_.source_dtc_id = id;
-		header_.link0_subsystem = static_cast<uint8_t>(subsystem);
-		header_.link1_subsystem = static_cast<uint8_t>(subsystem);
-		header_.link2_subsystem = static_cast<uint8_t>(subsystem);
-		header_.link3_subsystem = static_cast<uint8_t>(subsystem);
-		header_.link4_subsystem = static_cast<uint8_t>(subsystem);
-		header_.link5_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link0_subsystem = static_cast<uint8_t>(subsystems[0]);
+		header_.link1_subsystem = static_cast<uint8_t>(subsystems[1]);
+		header_.link2_subsystem = static_cast<uint8_t>(subsystems[2]);
+		header_.link3_subsystem = static_cast<uint8_t>(subsystems[3]);
+		header_.link4_subsystem = static_cast<uint8_t>(subsystems[4]);
+		header_.link5_subsystem = static_cast<uint8_t>(subsystems[5]);
 	}
 	const DTC_SubEventHeader* GetHeader() const { return &header_; }
 	void UpdateHeader();

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.h
@@ -87,7 +87,12 @@ public:
 	void SetSourceDTC(uint8_t id, DTC_Subsystem subsystem = DTC_Subsystem_Other)
 	{
 		header_.source_dtc_id = id;
-		header_.link0_subsystem = static_cast<uint8_t>(subsystem); //This is deprecated TODO FIX
+		header_.link0_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link1_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link2_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link3_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link4_subsystem = static_cast<uint8_t>(subsystem);
+		header_.link5_subsystem = static_cast<uint8_t>(subsystem);
 	}
 	const DTC_SubEventHeader* GetHeader() const { return &header_; }
 	void UpdateHeader();

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEventHeader.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEventHeader.h
@@ -24,8 +24,14 @@ struct DTC_SubEventHeader
 	uint64_t partition_id : 8;
 	uint64_t evb_mode : 8;
 	uint64_t source_dtc_id : 8;
-	uint64_t source_subsystem : 3;
-	uint64_t reserved2 : 29;
+
+	uint64_t link0_subsystem : 3;
+	uint64_t link1_subsystem : 3;
+	uint64_t link2_subsystem : 3;
+	uint64_t link3_subsystem : 3;
+	uint64_t link4_subsystem : 3;
+	uint64_t link5_subsystem : 3;
+	uint64_t reserved2 : 14;
 
 	uint64_t link0_status : 8;
 	uint64_t link1_status : 8;
@@ -57,6 +63,12 @@ struct DTC_SubEventHeader
 		, partition_id(0)
 		, evb_mode(0)
 		, source_dtc_id(0)
+		, link0_subsystem(0)
+		, link1_subsystem(0)
+		, link2_subsystem(0)
+		, link3_subsystem(0)
+		, link4_subsystem(0)
+		, link5_subsystem(0)
 		, reserved2(0)
 		, link0_status(0)
 		, link1_status(0)
@@ -89,6 +101,12 @@ struct DTC_SubEventHeader
 		oss << ",\n\t\"partition_id\": " << partition_id;
 		oss << ",\n\t\"evb_mode\": " << evb_mode;
 		oss << ",\n\t\"source_dtc_id\": " << source_dtc_id;
+		oss << ",\n\t\"link0_subsystem\": " << link0_subsystem;
+		oss << ",\n\t\"link1_subsystem\": " << link1_subsystem;
+		oss << ",\n\t\"link2_subsystem\": " << link2_subsystem;
+		oss << ",\n\t\"link3_subsystem\": " << link3_subsystem;
+		oss << ",\n\t\"link4_subsystem\": " << link4_subsystem;
+		oss << ",\n\t\"link5_subsystem\": " << link5_subsystem;
 		oss << ",\n\t\"link0_status\": " << link0_status;
 		oss << ",\n\t\"link1_status\": " << link1_status;
 		oss << ",\n\t\"link2_status\": " << link2_status;


### PR DESCRIPTION
Subevent header now has:
```
	uint64_t link0_subsystem : 3;
	uint64_t link1_subsystem : 3;
	uint64_t link2_subsystem : 3;
	uint64_t link3_subsystem : 3;
	uint64_t link4_subsystem : 3;
	uint64_t link5_subsystem : 3;
	uint64_t reserved2 : 14;
```
instead of the previous:
```
	uint64_t source_subsystem : 3;
	uint64_t reserved2 : 29;
```

Function
`std::vector<DTC_SubEvent> DTC_Event::GetSubsystemData(DTC_Subsystem subsys)`
has same behavior and returns all subevents with at least 1 subsys ROC

New function
`std::vector<DTC_DataBlock> DTC_Event::GetSubsystemBlocks(DTC_Subsystem subsys)`
directly returns the subsys datablocks.

Function
`DTC_Subsystem DTC_SubEvent::GetSubsystem(uint link = 0)`
is bacward compatible

Function
`void DTC_SubEvent::SetSourceDTC(uint8_t id, DTC_Subsystem subsystem = DTC_Subsystem_Other)`
is backward compatible but is **deprecated** and should be changed/removed.
A quick search finds these modules using this function:
- Offline/DAQ/src/ArtBinaryPacketsFromDigis_module.cc
- mu2e-pcie-utils/dtcInterfaceLib/mu2esim.cpp

**There is currently NO consistency check** between the SubEventHeader `link*_subsystem` and the DataBlock header `GetSubsystemID()`