### PR TITLE
Error handling for corrupted CRV hits

### DIFF
--- a/artdaq-core-mu2e/Data/CRVDataDecoder.cc
+++ b/artdaq-core-mu2e/Data/CRVDataDecoder.cc
@@ -41,6 +41,7 @@ bool mu2e::CRVDataDecoder::GetCRVHits(size_t blockIndex, std::vector<mu2e::CRVDa
             std::cerr << "EventWindowTag " << crvRocHdr->GetEventWindowTag() << std::endl;
             std::cerr << "************************************************" << std::endl;
 
+            crvHits.clear();
             return false;
           }
         }

--- a/artdaq-core-mu2e/Data/CRVDataDecoder.cc
+++ b/artdaq-core-mu2e/Data/CRVDataDecoder.cc
@@ -1,4 +1,5 @@
 #include "artdaq-core-mu2e/Data/CRVDataDecoder.hh"
+#include "artdaq-core-mu2e/Overlays/DTC_Types/Exceptions.h"
 
 std::unique_ptr<mu2e::CRVDataDecoder::CRVROCStatusPacket> mu2e::CRVDataDecoder::GetCRVROCStatusPacket(size_t blockIndex) const
 {
@@ -40,6 +41,8 @@ std::vector<mu2e::CRVDataDecoder::CRVHit> mu2e::CRVDataDecoder::GetCRVHits(size_
             std::cerr << "TriggerCount " << crvRocHdr->TriggerCount << std::endl;
             std::cerr << "EventWindowTag " << crvRocHdr->GetEventWindowTag() << std::endl;
             std::cerr << "************************************************" << std::endl;
+
+            throw std::runtime_error("Corrupted CRV data");
           }
         }
 

--- a/artdaq-core-mu2e/Data/CRVDataDecoder.hh
+++ b/artdaq-core-mu2e/Data/CRVDataDecoder.hh
@@ -109,7 +109,7 @@ public:
         typedef std::pair<CRVHitInfo,CRVHitWaveform> CRVHit;
 
 	std::unique_ptr<CRVROCStatusPacket> GetCRVROCStatusPacket(size_t blockIndex) const;
-	std::vector<CRVHit> GetCRVHits(size_t blockIndex) const;
+        bool GetCRVHits(size_t blockIndex, std::vector<CRVHit> &crvHits) const;
 
 };
   using CRVDataDecoders = std::vector<CRVDataDecoder>;


### PR DESCRIPTION
Added a check for corrupted CRV hits that can be handled in Offline.
This change has been tested with corrupted CRV data.