### PR TITLE
Move per-event TRACEs to higher levels so that they don't accidentially

### DIFF
--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.cpp
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_Event.cpp
@@ -5,17 +5,22 @@
 
 #include "TRACE/tracemf.h"
 
+static constexpr int TLVL_CONSTRUCTOR = TLVL_DEBUG + 10;
+static constexpr int TLVL_UPDATEHEADER = TLVL_DEBUG + 11;
+static constexpr int TLVL_SETUP = TLVL_DEBUG + 12;
+static constexpr int TLVL_WRITEEVENT = TLVL_DEBUG + 13;
+
 DTCLib::DTC_Event::DTC_Event(const void* data)
 	: header_(), sub_events_(), buffer_ptr_(data)
 {
 	memcpy(&header_, data, sizeof(header_));
-	TLOG(TLVL_TRACE) << "Header of DTC_Event " << GetEventWindowTag().GetEventWindowTag(true) << " created, copy in data and call SetupEvent to finalize";
+	TLOG(TLVL_CONSTRUCTOR) << "Header of DTC_Event " << GetEventWindowTag().GetEventWindowTag(true) << " created, copy in data and call SetupEvent to finalize";
 }
 
 DTCLib::DTC_Event::DTC_Event(size_t data_size)
 	: allocBytes(new std::vector<uint8_t>(data_size)), header_(), sub_events_(), buffer_ptr_(allocBytes->data())
 {
-	TLOG(TLVL_TRACE) << "Empty DTC_Event created, copy in data and call SetupEvent to finalize";
+	TLOG(TLVL_CONSTRUCTOR) << "Empty DTC_Event created, copy in data and call SetupEvent to finalize";
 }
 
 void DTCLib::DTC_Event::SetupEvent()
@@ -28,7 +33,7 @@ void DTCLib::DTC_Event::SetupEvent()
 	size_t byte_count = sizeof(header_);
 	while (byte_count < header_.inclusive_event_byte_count)
 	{
-		TLOG(TLVL_DEBUG + 6) << "Current byte_count is " << byte_count << " / " << header_.inclusive_event_byte_count << ", creating sub event";
+		TLOG(TLVL_SETUP) << "Current byte_count is " << byte_count << " / " << header_.inclusive_event_byte_count << ", creating sub event";
 		try
 		{
 			sub_events_.emplace_back(ptr);
@@ -41,7 +46,7 @@ void DTCLib::DTC_Event::SetupEvent()
 				TLOG(TLVL_ERROR) << "Invalid empty sub event byte count interpretation!";
 				throw ex;
 			}
-			TLOG(TLVL_DEBUG + 6) << "Found sub event byte_count of " << sub_events_.back().GetSubEventByteCount();
+			TLOG(TLVL_SETUP) << "Found sub event byte_count of " << sub_events_.back().GetSubEventByteCount();
 		}
 		catch (DTC_WrongPacketTypeException const& ex)
 		{
@@ -89,31 +94,31 @@ void DTCLib::DTC_Event::UpdateHeader()
 		sub_evt.UpdateHeader();
 		header_.inclusive_event_byte_count += sub_evt.GetSubEventByteCount();
 	}
-	TLOG(TLVL_TRACE) << "Inclusive Event Byte Count is now " << header_.inclusive_event_byte_count << " for event " << GetEventWindowTag().GetEventWindowTag(true);
+	TLOG(TLVL_UPDATEHEADER) << "Inclusive Event Byte Count is now " << header_.inclusive_event_byte_count << " for event " << GetEventWindowTag().GetEventWindowTag(true);
 }
 
 void DTCLib::DTC_Event::WriteEvent(std::ostream& o, bool includeDMAWriteSize)
 {
-	TLOG(TLVL_TRACE) << "Updating header byte counts";
+	TLOG(TLVL_WRITEEVENT) << "Updating header byte counts";
 	UpdateHeader();
 
 	if (header_.inclusive_event_byte_count + sizeof(uint64_t) + (includeDMAWriteSize ? sizeof(uint64_t) : 0) < MAX_DMA_SIZE)
 	{
-		TLOG(TLVL_TRACE) << "Event fits into one buffer, writing";
+		TLOG(TLVL_WRITEEVENT) << "Event fits into one buffer, writing";
 		auto pos = o.tellp();
 		Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, header_.inclusive_event_byte_count, pos, false);
 
-		TLOG(TLVL_TRACE) << "Writing DTC_EventHeader for event " << GetEventWindowTag().GetEventWindowTag(true) << " sz=" << sizeof(DTC_EventHeader);
+		TLOG(TLVL_WRITEEVENT) << "Writing DTC_EventHeader for event " << GetEventWindowTag().GetEventWindowTag(true) << " sz=" << sizeof(DTC_EventHeader);
 		o.write(reinterpret_cast<const char*>(&header_), sizeof(DTC_EventHeader));
 
 		for (auto& subevt : sub_events_)
 		{
-			TLOG(TLVL_TRACE) << "Writing DTC_SubEventHeader for DTC " << static_cast<int>(subevt.GetDTCID()) << " sz=" << sizeof(DTC_SubEventHeader);
+			TLOG(TLVL_WRITEEVENT) << "Writing DTC_SubEventHeader for DTC " << static_cast<int>(subevt.GetDTCID()) << " sz=" << sizeof(DTC_SubEventHeader);
 			o.write(reinterpret_cast<const char*>(subevt.GetHeader()), sizeof(DTC_SubEventHeader));
 			auto ii = 0;
 			for (auto& blk : subevt.GetDataBlocks())
 			{
-				TLOG(TLVL_TRACE) << "Writing Data Block " << ii << ", roc=" << blk.GetHeader()->GetLinkID() << ", sz=" << blk.byteSize;
+				TLOG(TLVL_WRITEEVENT) << "Writing Data Block " << ii << ", roc=" << blk.GetHeader()->GetLinkID() << ", sz=" << blk.byteSize;
 				o.write(static_cast<const char*>(blk.blockPointer), blk.byteSize);
 				++ii;
 			}
@@ -121,7 +126,7 @@ void DTCLib::DTC_Event::WriteEvent(std::ostream& o, bool includeDMAWriteSize)
 	}
 	else
 	{
-		TLOG(TLVL_TRACE) << "Event spans multiple buffers, beginning write";
+		TLOG(TLVL_WRITEEVENT) << "Event spans multiple buffers, beginning write";
 		auto buffer_start = o.tellp();
 		size_t bytes_written = Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, header_.inclusive_event_byte_count, buffer_start, false);
 
@@ -133,11 +138,11 @@ void DTCLib::DTC_Event::WriteEvent(std::ostream& o, bool includeDMAWriteSize)
 		{
 			if (bytes_written + buffer_data_size + sizeof(DTC_SubEventHeader) > MAX_DMA_SIZE)
 			{
-				TLOG(TLVL_TRACE) << "Starting new buffer, writing size words " << buffer_data_size << " to old buffer";
+				TLOG(TLVL_WRITEEVENT) << "Starting new buffer, writing size words " << buffer_data_size << " to old buffer";
 				Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, buffer_data_size, buffer_start, true);
 				buffer_start = o.tellp();
 				total_data_size += buffer_data_size;
-				TLOG(TLVL_TRACE) << "Writing anticipated data size " << header_.inclusive_event_byte_count - total_data_size << " to new buffer.";
+				TLOG(TLVL_WRITEEVENT) << "Writing anticipated data size " << header_.inclusive_event_byte_count - total_data_size << " to new buffer.";
 				bytes_written = Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, header_.inclusive_event_byte_count - total_data_size, buffer_start, false);
 				buffer_data_size = 0;
 			}
@@ -147,11 +152,11 @@ void DTCLib::DTC_Event::WriteEvent(std::ostream& o, bool includeDMAWriteSize)
 			{
 				if (bytes_written + buffer_data_size + blk.byteSize > MAX_DMA_SIZE)
 				{
-					TLOG(TLVL_TRACE) << "Starting new buffer, writing size words " << buffer_data_size << " to old buffer";
+					TLOG(TLVL_WRITEEVENT) << "Starting new buffer, writing size words " << buffer_data_size << " to old buffer";
 					Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, buffer_data_size, buffer_start, true);
 					buffer_start = o.tellp();
 					total_data_size += buffer_data_size;
-					TLOG(TLVL_TRACE) << "Writing anticipated data size " << header_.inclusive_event_byte_count - total_data_size << " to new buffer.";
+					TLOG(TLVL_WRITEEVENT) << "Writing anticipated data size " << header_.inclusive_event_byte_count - total_data_size << " to new buffer.";
 					bytes_written = Utilities::WriteDMABufferSizeWords(o, includeDMAWriteSize, header_.inclusive_event_byte_count - total_data_size, buffer_start, false);
 					buffer_data_size = 0;
 				}

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.cpp
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.cpp
@@ -115,16 +115,16 @@ void DTCLib::DTC_SubEvent::SetupSubEvent()
 			// printout ROC fragment data block
 			if (data_block_byte_count > 16 * 2)  // more than 2 packets
 				TLOG(TLVL_SETUP_VERBOSE_2) << "Beginning "
-									 << std::hex << std::setw(8) << std::setfill('0')
-									 << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[4 * 4]))) << ' ' << *((uint32_t *)(&(ptr[5 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[6 * 4]))) << ' ' << *((uint32_t *)(&(ptr[7 * 4])));
+										   << std::hex << std::setw(8) << std::setfill('0')
+										   << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[4 * 4]))) << ' ' << *((uint32_t *)(&(ptr[5 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[6 * 4]))) << ' ' << *((uint32_t *)(&(ptr[7 * 4])));
 			else
 				TLOG(TLVL_SETUP_VERBOSE_2) << "Beginning "
-									 << std::hex << std::setw(8) << std::setfill('0')
-									 << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4])));
+										   << std::hex << std::setw(8) << std::setfill('0')
+										   << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4])));
 
 			if (data_block_byte_count > 8 * 4)
 			{
@@ -143,11 +143,11 @@ void DTCLib::DTC_SubEvent::SetupSubEvent()
 
 				size_t i = data_block_byte_count - 8 * 4;
 				TLOG(TLVL_SETUP_VERBOSE_2) << "End (starting at data block word #" << i << ") "
-									 << std::hex << std::setw(8) << std::setfill('0')
-									 << *((uint32_t *)(&(ptr[i + 0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 1 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[i + 2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 3 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[i + 4 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 5 * 4]))) << ' '
-									 << *((uint32_t *)(&(ptr[i + 6 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 7 * 4])));
+										   << std::hex << std::setw(8) << std::setfill('0')
+										   << *((uint32_t *)(&(ptr[i + 0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 1 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[i + 2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 3 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[i + 4 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 5 * 4]))) << ' '
+										   << *((uint32_t *)(&(ptr[i + 6 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 7 * 4])));
 			}
 
 			if (data_blocks_.back().GetHeader()->GetLinkID() != roc_fragi)

--- a/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.cpp
+++ b/artdaq-core-mu2e/Overlays/DTC_Packets/DTC_SubEvent.cpp
@@ -6,11 +6,17 @@
 
 const uint8_t DTCLib::DTC_SubEvent::REQUIRED_SUBEVENT_FORMAT_VERSION = 1;
 
+static constexpr int TLVL_CONSTRUCTOR = TLVL_DEBUG + 10;
+static constexpr int TLVL_UPDATEHEADER = TLVL_DEBUG + 11;
+static constexpr int TLVL_SETUP = TLVL_DEBUG + 12;
+static constexpr int TLVL_SETUP_VERBOSE = TLVL_DEBUG + 13;
+static constexpr int TLVL_SETUP_VERBOSE_2 = TLVL_DEBUG + 14;
+
 DTCLib::DTC_SubEvent::DTC_SubEvent(const void *data)
 	: header_(), data_blocks_(), buffer_ptr_(data)
 {
 	memcpy(&header_, data, sizeof(header_));
-	TLOG(TLVL_TRACE) << "Header of DTC_SubEvent created, copy in data and call SetupSubEvent to finalize";
+	TLOG(TLVL_CONSTRUCTOR) << "Header of DTC_SubEvent created, copy in data and call SetupSubEvent to finalize";
 	// Moved remainder to SetupSubEvent() to allow for SubEvents to cross DMA transfers
 	if (header_.subevent_format_version != REQUIRED_SUBEVENT_FORMAT_VERSION)
 	{
@@ -27,7 +33,7 @@ DTCLib::DTC_SubEvent::DTC_SubEvent(const void *data)
 DTCLib::DTC_SubEvent::DTC_SubEvent(size_t data_size)
 	: allocBytes(new std::vector<uint8_t>(data_size)), header_(), data_blocks_(), buffer_ptr_(allocBytes->data())
 {
-	TLOG(TLVL_TRACE) << "Empty DTC_SubEvent created, copy in data and call SetupSubEvent to finalize, data_size = " << data_size;
+	TLOG(TLVL_CONSTRUCTOR) << "Empty DTC_SubEvent created, copy in data and call SetupSubEvent to finalize, data_size = " << data_size;
 }
 
 DTCLib::DTC_EventWindowTag DTCLib::DTC_SubEvent::GetEventWindowTag() const
@@ -66,7 +72,7 @@ void DTCLib::DTC_SubEvent::UpdateHeader()
 	{
 		header_.inclusive_subevent_byte_count += block.byteSize;
 	}
-	TLOG(TLVL_TRACE) << "Inclusive SubEvent Byte Count is now " << header_.inclusive_subevent_byte_count << " for subevent " << static_cast<int>(GetDTCID());
+	TLOG(TLVL_UPDATEHEADER) << "Inclusive SubEvent Byte Count is now " << header_.inclusive_subevent_byte_count << " for subevent " << static_cast<int>(GetDTCID());
 }
 
 void DTCLib::DTC_SubEvent::SetupSubEvent()
@@ -86,36 +92,36 @@ void DTCLib::DTC_SubEvent::SetupSubEvent()
 		testss << "subevent header Tag=" << GetEventWindowTag().GetEventWindowTag(true) << " (0x" << std::hex << GetEventWindowTag().GetEventWindowTag(true) << ") bytes=" << std::dec << sizeof(header_) << ": 0x ";
 		for (size_t i = 0; i < sizeof(header_); i += 4)
 			testss << std::hex << std::setw(8) << std::setfill('0') << *((uint32_t *)(&(ptr[i]))) << ' ';
-		TLOG(TLVL_DEBUG + 6) << testss.str();
-		TLOG(TLVL_DEBUG + 6) << header_.toJson();
+		TLOG(TLVL_SETUP_VERBOSE) << testss.str();
+		TLOG(TLVL_SETUP_VERBOSE) << header_.toJson();
 	}
 	ptr += sizeof(header_);  // moving ptr past subevent header
 
-	TLOG(TLVL_DEBUG + 6) << "Found sub event inclusive byte count as: " << header_.inclusive_subevent_byte_count << " 0x" << std::hex << std::setw(4) << std::setfill('0') << header_.inclusive_subevent_byte_count << ". i.e., " << std::dec << std::setw(0) << (header_.inclusive_subevent_byte_count - sizeof(header_)) / 16 << " subevent packets.";
+	TLOG(TLVL_SETUP) << "Found sub event inclusive byte count as: " << header_.inclusive_subevent_byte_count << " 0x" << std::hex << std::setw(4) << std::setfill('0') << header_.inclusive_subevent_byte_count << ". i.e., " << std::dec << std::setw(0) << (header_.inclusive_subevent_byte_count - sizeof(header_)) / 16 << " subevent packets.";
 
 	size_t byte_count = sizeof(header_);
 	uint8_t roc_fragi = -1;
 	while (byte_count < header_.inclusive_subevent_byte_count)
 	{
 		++roc_fragi;
-		TLOG(TLVL_DEBUG + 6) << "Current byte_count is " << byte_count << " / " << header_.inclusive_subevent_byte_count << ", creating block";
+		TLOG(TLVL_SETUP) << "Current byte_count is " << byte_count << " / " << header_.inclusive_subevent_byte_count << ", creating block";
 		try
 		{
 			data_blocks_.emplace_back(static_cast<const void *>(ptr));
 			auto data_block_byte_count = data_blocks_.back().byteSize;
 			byte_count += data_block_byte_count;
-			TLOG(TLVL_DEBUG + 6) << "Found ROC fragment #" << static_cast<int>(roc_fragi) << " block of byte_count " << data_block_byte_count << " 0x" << std::hex << data_block_byte_count << " (i.e., " << std::dec << data_block_byte_count / 16 << " fragment packets).";
+			TLOG(TLVL_SETUP) << "Found ROC fragment #" << static_cast<int>(roc_fragi) << " block of byte_count " << data_block_byte_count << " 0x" << std::hex << data_block_byte_count << " (i.e., " << std::dec << data_block_byte_count / 16 << " fragment packets).";
 
 			// printout ROC fragment data block
 			if (data_block_byte_count > 16 * 2)  // more than 2 packets
-				TLOG(TLVL_DEBUG + 6) << "Beginning "
+				TLOG(TLVL_SETUP_VERBOSE_2) << "Beginning "
 									 << std::hex << std::setw(8) << std::setfill('0')
 									 << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
 									 << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4]))) << ' '
 									 << *((uint32_t *)(&(ptr[4 * 4]))) << ' ' << *((uint32_t *)(&(ptr[5 * 4]))) << ' '
 									 << *((uint32_t *)(&(ptr[6 * 4]))) << ' ' << *((uint32_t *)(&(ptr[7 * 4])));
 			else
-				TLOG(TLVL_DEBUG + 6) << "Beginning "
+				TLOG(TLVL_SETUP_VERBOSE_2) << "Beginning "
 									 << std::hex << std::setw(8) << std::setfill('0')
 									 << *((uint32_t *)(&(ptr[0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[1 * 4]))) << ' '
 									 << *((uint32_t *)(&(ptr[2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[3 * 4])));
@@ -136,7 +142,7 @@ void DTCLib::DTC_SubEvent::SetupSubEvent()
 				// }
 
 				size_t i = data_block_byte_count - 8 * 4;
-				TLOG(TLVL_DEBUG + 6) << "End (starting at data block word #" << i << ") "
+				TLOG(TLVL_SETUP_VERBOSE_2) << "End (starting at data block word #" << i << ") "
 									 << std::hex << std::setw(8) << std::setfill('0')
 									 << *((uint32_t *)(&(ptr[i + 0 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 1 * 4]))) << ' '
 									 << *((uint32_t *)(&(ptr[i + 2 * 4]))) << ' ' << *((uint32_t *)(&(ptr[i + 3 * 4]))) << ' '


### PR DESCRIPTION
get activated. Part of https://github.com/Mu2e/daq-operations/issues/23