### PR TITLE
Exclude TRACE include from ROOTCLING

### DIFF
--- a/artdaq-core-mu2e/Overlays/DTC_Types/DTC_Link_ID.h
+++ b/artdaq-core-mu2e/Overlays/DTC_Types/DTC_Link_ID.h
@@ -5,7 +5,9 @@
 #include <ostream>
 #include <vector>  // std::vector
 
+#ifndef __ROOTCLING__
 #include "TRACE/trace.h"
+#endif
 
 namespace DTCLib
 {
@@ -24,10 +26,12 @@ enum DTC_Link_ID : uint8_t
 	DTC_Link_ALL = 255
 };
 
+#ifndef __ROOTCLING__
 inline TraceStreamer& operator<<(TraceStreamer& ts, DTC_Link_ID const& link)
 {
 	return ts << static_cast<unsigned int>(link);
 }
+#endif
 
 inline std::ostream& operator<<(std::ostream& o, DTC_Link_ID const& link)
 {


### PR DESCRIPTION
Ryan's last PR broke RecoDataProduct's dictionary generation since ROOT can't parse TRACE.h